### PR TITLE
Adapt to SPI changes in JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.3.1</version>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.3.1</version>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/profilers/FlightRecordingProfiler.java
+++ b/src/main/java/profilers/FlightRecordingProfiler.java
@@ -2,10 +2,7 @@ package profilers;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.profile.ExternalProfiler;
-import org.openjdk.jmh.results.AggregationPolicy;
-import org.openjdk.jmh.results.Aggregator;
-import org.openjdk.jmh.results.Result;
-import org.openjdk.jmh.results.ResultRole;
+import org.openjdk.jmh.results.*;
 import org.openjdk.jmh.util.FileUtils;
 
 import java.io.File;
@@ -80,9 +77,8 @@ public class FlightRecordingProfiler implements ExternalProfiler {
     static int currentId;
 
     @Override
-    public Collection<? extends Result> afterTrial(BenchmarkParams benchmarkParams, File stdOut, File stdErr) {
-
-        String target = SAVE_FLIGHT_OUTPUT_TO + "/" + benchmarkParams.id() + "-" + currentId++ + ".jfr";
+    public Collection<? extends Result> afterTrial(BenchmarkResult benchmarkResult, long l, File stdOut, File stdErr) {
+        String target = SAVE_FLIGHT_OUTPUT_TO + "/" + benchmarkResult.getParams().id() + "-" + currentId++ + ".jfr";
 
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
@@ -148,13 +144,13 @@ public class FlightRecordingProfiler implements ExternalProfiler {
         }
 
         @Override
-        public String extendedInfo(String label) {
+        public String extendedInfo() {
             return "JFR Messages:\n--------------------------------------------\n" + output;
         }
 
         private class NoResultAggregator implements Aggregator<NoResult> {
             @Override
-            public Result aggregate(Collection<NoResult> results) {
+            public NoResult aggregate(Collection<NoResult> results) {
                 String output = "";
                 for (NoResult r : results) {
                     output += r.output;


### PR DESCRIPTION
Only tested with JMH 1.8.

The following changesets touched `ProfilerInterface` since JMH 1.3.1:

```
1160:ea66b1770352e0f5b44f09f1fbe23775dfb087a5	20/03/15 01:54	shade	7901346: Profilers should be able to know the actual warmup/measurement durations
1125:61fd51cdd7ebac4de48bbe718563a279afabf4bb	13/02/15 06:15	shade	7901293: Windows/xperf support in perfasm...
```